### PR TITLE
Fix uniform distribution on ball

### DIFF
--- a/sample_hypersphere.m
+++ b/sample_hypersphere.m
@@ -5,7 +5,7 @@ function pts = sample_hypersphere(n,N)
 
     pts(:,1) = zeros(n,1);
 
-    tmp = 2*rand(n,N-1)-1;
+    tmp = randn(n,N-1);
     tmp = tmp./vecnorm(tmp,2,1);
     pts(:,2:N) = (rand(1,N-1).^(1/n)).*tmp;
     


### PR DESCRIPTION
The current implementation does not give a uniform distribution, e.g., in 2d it is slightly more concentrated on the diagonals. This is fixed by using a normal distribution and normalizing afterwards.